### PR TITLE
Add TH typed splice syntax kludge for Floskell

### DIFF
--- a/cli-app.hsfiles
+++ b/cli-app.hsfiles
@@ -237,6 +237,11 @@ tests:
         "spaces": "both",
         "linebreaks": "after"
       },
+      "$$": {
+        "force-linebreak": false,
+        "spaces": "before",
+        "linebreaks": "none"
+      },
       "record in pattern": {
         "force-linebreak": false,
         "spaces": "none",

--- a/serverless.hsfiles
+++ b/serverless.hsfiles
@@ -128,6 +128,11 @@ node
         "spaces": "both",
         "linebreaks": "after"
       },
+      "$$": {
+        "force-linebreak": false,
+        "spaces": "before",
+        "linebreaks": "none"
+      },
       "record in pattern": {
         "force-linebreak": false,
         "spaces": "none",


### PR DESCRIPTION
Floskell does not recognise the `$$(splice)` syntax for Template Haskell typed
splices, and automatically formats it to `$$ (splice)` causing a compile
error. This change recognises the unknown syntax and formats it
correctly.