### PR TITLE
Tweak floskell config for readability

### DIFF
--- a/cli-app.hsfiles
+++ b/cli-app.hsfiles
@@ -181,6 +181,7 @@ tests:
     "RecordWildCards",
     "ScopedTypeVariables",
     "StandaloneDeriving",
+    "TemplateHaskell",
     "TupleSections",
     "TypeApplications",
     "TypeFamilies",
@@ -207,6 +208,11 @@ tests:
         "spaces": "both",
         "linebreaks": "after"
       },
+      "$$": {
+        "force-linebreak": false,
+        "spaces": "before",
+        "linebreaks": "none"
+      },
       "@": {
         "force-linebreak": false,
         "spaces": "none",
@@ -232,25 +238,10 @@ tests:
         "spaces": "after",
         "linebreaks": "after"
       },
-      "$": {
-        "force-linebreak": false,
-        "spaces": "both",
-        "linebreaks": "after"
-      },
-      "$$": {
-        "force-linebreak": false,
-        "spaces": "before",
-        "linebreaks": "none"
-      },
       "record in pattern": {
         "force-linebreak": false,
         "spaces": "none",
         "linebreaks": "none"
-      },
-      "<*> in expression": {
-        "force-linebreak": true,
-        "spaces": "both",
-        "linebreaks": "before"
       }
     },
     "group": {
@@ -321,7 +312,7 @@ tests:
       }
     },
     "layout": {
-      "infix-app": "flex",
+      "infix-app": "try-oneline",
       "if": "try-oneline",
       "import-spec-list": "try-oneline",
       "con-decls": "try-oneline",

--- a/serverless.hsfiles
+++ b/serverless.hsfiles
@@ -78,14 +78,21 @@ node
     "RecordWildCards",
     "ScopedTypeVariables",
     "StandaloneDeriving",
+    "TemplateHaskell",
     "TupleSections",
     "TypeApplications",
     "TypeFamilies",
     "TypeFamilyDependencies",
     "TypeSynonymInstances",
-    "TypeOperators"
+    "TypeOperators",
+    "ViewPatterns"
   ],
-  "fixities": [],
+  "fixities": [
+    "infixl 8 <%?>",
+    "infixl 8 <%!?>",
+    "infixl 8 <?>",
+    "infixl 8 <!?>"
+  ],
   "formatting": {
     "op": {
       ",": {
@@ -97,6 +104,11 @@ node
         "force-linebreak": false,
         "spaces": "both",
         "linebreaks": "after"
+      },
+      "$$": {
+        "force-linebreak": false,
+        "spaces": "before",
+        "linebreaks": "none"
       },
       "@": {
         "force-linebreak": false,
@@ -123,25 +135,10 @@ node
         "spaces": "after",
         "linebreaks": "after"
       },
-      "$": {
-        "force-linebreak": false,
-        "spaces": "both",
-        "linebreaks": "after"
-      },
-      "$$": {
-        "force-linebreak": false,
-        "spaces": "before",
-        "linebreaks": "none"
-      },
       "record in pattern": {
         "force-linebreak": false,
         "spaces": "none",
         "linebreaks": "none"
-      },
-      "<*> in expression": {
-        "force-linebreak": true,
-        "spaces": "both",
-        "linebreaks": "before"
       }
     },
     "group": {
@@ -212,7 +209,7 @@ node
       }
     },
     "layout": {
-      "infix-app": "flex",
+      "infix-app": "try-oneline",
       "if": "try-oneline",
       "import-spec-list": "try-oneline",
       "con-decls": "try-oneline",
@@ -290,9 +287,10 @@ node
         },
         {
           "prefixes": [
-            "Test"
+            "Test",
+            "Hedgehog"
           ],
-          "order": "grouped"
+          "order": "sorted"
         }
       ]
     }


### PR DESCRIPTION
* Add TemplateHaskell.
* Make chains of `$` appear on separate lines at the start of the line, if possible.
* Make chains of `<*>` appear on separate lines at the start of the line.
* Bring serverless floskell in line with the cli floskell.

Question: Is there a better way to manage floskell config? If we institute a formatting change somewhere, it has to be copied to every project manually. Is there some automatic way to do this? e.g. by commit hook?